### PR TITLE
ECL-870: Improved Financial Details integration tests and removed retries on that API call

### DIFF
--- a/app/uk/gov/hmrc/economiccrimelevyaccount/connectors/DesConnector.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyaccount/connectors/DesConnector.scala
@@ -19,12 +19,11 @@ package uk.gov.hmrc.economiccrimelevyaccount.connectors
 import com.typesafe.config.Config
 import org.apache.pekko.actor.ActorSystem
 import play.api.Logging
-import play.api.http.HeaderNames
 import uk.gov.hmrc.economiccrimelevyaccount.config.AppConfig
 import uk.gov.hmrc.economiccrimelevyaccount.models.{CustomHeaderNames, EclReference}
 import uk.gov.hmrc.economiccrimelevyaccount.models.des.ObligationData
 import uk.gov.hmrc.http.client.HttpClientV2
-import uk.gov.hmrc.http.{HeaderCarrier, Retries, StringContextOps}
+import uk.gov.hmrc.http.{HeaderCarrier, HeaderNames, Retries, StringContextOps}
 
 import java.time.{LocalDate, ZoneOffset}
 import javax.inject.{Inject, Singleton}
@@ -42,8 +41,8 @@ class DesConnector @Inject() (
     with Logging {
 
   private val desHeaders: Seq[(String, String)] = Seq(
-    (HeaderNames.AUTHORIZATION, s"Bearer ${appConfig.desBearerToken}"),
-    (CustomHeaderNames.Environment, appConfig.desEnvironment)
+    (HeaderNames.authorisation, s"Bearer ${appConfig.desBearerToken}"),
+    (CustomHeaderNames.environment, appConfig.desEnvironment)
   )
 
   private def desUrl(eclRegistrationReference: String) =

--- a/app/uk/gov/hmrc/economiccrimelevyaccount/connectors/IntegrationFrameworkConnector.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyaccount/connectors/IntegrationFrameworkConnector.scala
@@ -16,17 +16,13 @@
 
 package uk.gov.hmrc.economiccrimelevyaccount.connectors
 
-import com.typesafe.config.Config
 import io.lemonlabs.uri.{QueryString, Url}
-import org.apache.pekko.actor.ActorSystem
 import play.api.Logging
-import play.api.http.HeaderNames
 import uk.gov.hmrc.economiccrimelevyaccount.config.AppConfig
 import uk.gov.hmrc.economiccrimelevyaccount.models.integrationframework._
 import uk.gov.hmrc.economiccrimelevyaccount.models.{CustomHeaderNames, EclReference, QueryParams}
-import uk.gov.hmrc.economiccrimelevyaccount.utils.CorrelationIdHelper.HEADER_X_CORRELATION_ID
 import uk.gov.hmrc.http.client.HttpClientV2
-import uk.gov.hmrc.http.{HeaderCarrier, Retries, StringContextOps}
+import uk.gov.hmrc.http.{HeaderCarrier, HeaderNames, StringContextOps}
 
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -37,12 +33,9 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class IntegrationFrameworkConnector @Inject() (
   appConfig: AppConfig,
-  httpClient: HttpClientV2,
-  override val configuration: Config,
-  override val actorSystem: ActorSystem
+  httpClient: HttpClientV2
 )(implicit ec: ExecutionContext)
     extends BaseConnector
-    with Retries
     with Logging {
 
   private def ifUrl(eclRegistrationReference: String) = Url(
@@ -53,19 +46,17 @@ class IntegrationFrameworkConnector @Inject() (
   def getFinancialDetails(
     eclReference: EclReference
   )(implicit hc: HeaderCarrier): Future[FinancialData] = {
-    val correlationId = hc.headers(scala.Seq(HEADER_X_CORRELATION_ID)) match {
+    val correlationId = hc.headers(scala.Seq(CustomHeaderNames.xCorrelationId)) match {
       case Nil          =>
         UUID.randomUUID().toString
       case Seq((_, id)) =>
         id
     }
 
-    retryFor[FinancialData]("Integration framework - financial data")(retryCondition) {
-      httpClient
-        .get(url"${ifUrl(eclReference.value)}")
-        .setHeader(integrationFrameworkHeaders(correlationId): _*)
-        .executeAndDeserialise[FinancialData]
-    }
+    httpClient
+      .get(url"${ifUrl(eclReference.value)}")
+      .setHeader(integrationFrameworkHeaders(correlationId): _*)
+      .executeAndDeserialise[FinancialData]
   }
 
   private def financialDetailsQueryParams: Seq[(String, String)] = Seq(
@@ -87,8 +78,8 @@ class IntegrationFrameworkConnector @Inject() (
 
   private def integrationFrameworkHeaders(correlationId: String): Seq[(String, String)] =
     Seq(
-      (HeaderNames.AUTHORIZATION, s"Bearer ${appConfig.integrationFrameworkBearerToken}"),
-      (CustomHeaderNames.Environment, appConfig.integrationFrameworkEnvironment),
-      (CustomHeaderNames.CorrelationId, correlationId)
+      (HeaderNames.authorisation, s"Bearer ${appConfig.integrationFrameworkBearerToken}"),
+      (CustomHeaderNames.environment, appConfig.integrationFrameworkEnvironment),
+      (CustomHeaderNames.correlationId, correlationId)
     )
 }

--- a/app/uk/gov/hmrc/economiccrimelevyaccount/models/CustomHeaderNames.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyaccount/models/CustomHeaderNames.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.economiccrimelevyaccount.models
 
 object CustomHeaderNames {
-  val Environment   = "Environment"
-  val CorrelationId = "CorrelationId"
+  val correlationId  = "CorrelationId"
+  val environment    = "Environment"
+  val xCorrelationId = "X-Correlation-Id"
 }

--- a/app/uk/gov/hmrc/economiccrimelevyaccount/utils/CorrelationIdHelper.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyaccount/utils/CorrelationIdHelper.scala
@@ -18,22 +18,21 @@ package uk.gov.hmrc.economiccrimelevyaccount.utils
 
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.http.HeaderCarrierConverter
+
 import java.util.UUID
 import play.api.mvc.Request
+import uk.gov.hmrc.economiccrimelevyaccount.models.CustomHeaderNames
 
 object CorrelationIdHelper {
-
-  val HEADER_X_CORRELATION_ID: String = "X-Correlation-Id"
 
   def headerCarrierWithCorrelationId(request: Request[_]): HeaderCarrier = {
     val hcFromRequest: HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(request, request.session)
     hcFromRequest
-      .headers(scala.Seq(HEADER_X_CORRELATION_ID)) match {
+      .headers(scala.Seq(CustomHeaderNames.xCorrelationId)) match {
       case Nil =>
-        hcFromRequest.withExtraHeaders((HEADER_X_CORRELATION_ID, UUID.randomUUID().toString))
+        hcFromRequest.withExtraHeaders((CustomHeaderNames.xCorrelationId, UUID.randomUUID().toString))
       case _   =>
         hcFromRequest
     }
   }
-
 }

--- a/it/uk/gov/hmrc/economiccrimelevyaccount/FinancialDetailsISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyaccount/FinancialDetailsISpec.scala
@@ -1,22 +1,88 @@
 package uk.gov.hmrc.economiccrimelevyaccount
 
+import com.github.tomakehurst.wiremock.client.WireMock._
+import org.scalatest.concurrent.Eventually.eventually
 import play.api.test.FakeRequest
 import uk.gov.hmrc.economiccrimelevyaccount.base.ISpecBase
 import uk.gov.hmrc.economiccrimelevyaccount.controllers.routes
+import uk.gov.hmrc.economiccrimelevyaccount.models.CustomHeaderNames
+import uk.gov.hmrc.http.HeaderNames
 
 class FinancialDetailsISpec extends ISpecBase {
 
+  private val getFinancialDetailsRegex = "/penalty/financial-data/ZECL/.*"
+
   s"GET ${routes.FinancialDataController.getFinancialData.url}" should {
     "return 200 OK with the financial data JSON when financial is returned" in {
+      resetAllRequests()
       stubAuthorised()
 
-      stubGetFinancialDetails()
+      stubGetFinancialDetailsSuccess()
 
       val result = callRoute(
         FakeRequest(routes.FinancialDataController.getFinancialData)
       )
 
       status(result) shouldBe OK
+
+      eventually {
+        verify(
+          1,
+          getRequestedFor(urlMatching(getFinancialDetailsRegex))
+            .withHeader(HeaderNames.authorisation, equalTo(s"Bearer ${appConfig.integrationFrameworkBearerToken}"))
+            .withHeader(CustomHeaderNames.environment, equalTo(appConfig.integrationFrameworkEnvironment))
+            .withHeader(CustomHeaderNames.correlationId, matching(uuidRegex))
+            .withHeader(CustomHeaderNames.xCorrelationId, matching(uuidRegex))
+        )
+      }
+    }
+
+    "return 502 BAD_GATEWAY with the financial data JSON when 409 CONFLICT is returned from financial details" in {
+      resetAllRequests()
+      stubAuthorised()
+
+      stubGetFinancialDetails409()
+
+      val result = callRoute(
+        FakeRequest(routes.FinancialDataController.getFinancialData)
+      )
+
+      status(result) shouldBe BAD_GATEWAY
+
+      eventually {
+        verify(
+          1,
+          getRequestedFor(urlMatching(getFinancialDetailsRegex))
+            .withHeader(HeaderNames.authorisation, equalTo(s"Bearer ${appConfig.integrationFrameworkBearerToken}"))
+            .withHeader(CustomHeaderNames.environment, equalTo(appConfig.integrationFrameworkEnvironment))
+            .withHeader(CustomHeaderNames.correlationId, matching(uuidRegex))
+            .withHeader(CustomHeaderNames.xCorrelationId, matching(uuidRegex))
+        )
+      }
+    }
+
+    "return 502 BAD_GATEWAY with the financial data JSON when 422 UNPROCESSABLE_ENTITY is returned from financial details" in {
+      resetAllRequests()
+      stubAuthorised()
+
+      stubGetFinancialDetails422()
+
+      val result = callRoute(
+        FakeRequest(routes.FinancialDataController.getFinancialData)
+      )
+
+      status(result) shouldBe BAD_GATEWAY
+
+      eventually {
+        verify(
+          1,
+          getRequestedFor(urlMatching(getFinancialDetailsRegex))
+            .withHeader(HeaderNames.authorisation, equalTo(s"Bearer ${appConfig.integrationFrameworkBearerToken}"))
+            .withHeader(CustomHeaderNames.environment, equalTo(appConfig.integrationFrameworkEnvironment))
+            .withHeader(CustomHeaderNames.correlationId, matching(uuidRegex))
+            .withHeader(CustomHeaderNames.xCorrelationId, matching(uuidRegex))
+        )
+      }
     }
   }
 }

--- a/it/uk/gov/hmrc/economiccrimelevyaccount/base/ISpecBase.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyaccount/base/ISpecBase.scala
@@ -19,6 +19,7 @@ import play.api.mvc.{Result, Results}
 import play.api.test._
 import play.api.{Application, Mode}
 import uk.gov.hmrc.economiccrimelevyaccount.base.WireMockHelper.setWireMockPort
+import uk.gov.hmrc.economiccrimelevyaccount.config.AppConfig
 
 import java.time.temporal.ChronoUnit
 import java.time.{Clock, Instant, ZoneId}
@@ -53,6 +54,7 @@ abstract class ISpecBase
 
   implicit lazy val system: ActorSystem        = ActorSystem()
   implicit lazy val materializer: Materializer = Materializer(system)
+  lazy val appConfig: AppConfig                = app.injector.instanceOf[AppConfig]
   implicit def ec: ExecutionContext            = global
 
   val now: Instant             = Instant.now.truncatedTo(ChronoUnit.MILLIS)

--- a/it/uk/gov/hmrc/economiccrimelevyaccount/base/IntegrationFrameworkStubs.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyaccount/base/IntegrationFrameworkStubs.scala
@@ -2,7 +2,7 @@ package uk.gov.hmrc.economiccrimelevyaccount.base
 
 import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, get, urlPathMatching}
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
-import play.api.http.Status.OK
+import play.api.http.Status.{CONFLICT, OK, UNPROCESSABLE_ENTITY}
 import uk.gov.hmrc.economiccrimelevyaccount.base.WireMockHelper.stub
 
 trait IntegrationFrameworkStubs { self: WireMockStubs =>
@@ -95,7 +95,7 @@ trait IntegrationFrameworkStubs { self: WireMockStubs =>
       |}
       |""".stripMargin
 
-  def stubGetFinancialDetails(): StubMapping =
+  def stubGetFinancialDetailsSuccess(): StubMapping =
     stub(
       get(
         urlPathMatching("^/penalty/financial-data/ZECL/.*")
@@ -103,6 +103,30 @@ trait IntegrationFrameworkStubs { self: WireMockStubs =>
       aResponse()
         .withStatus(OK)
         .withBody(validFinancialDetailsResponse)
+    )
+
+  def stubGetFinancialDetails409(): StubMapping =
+    stub(
+      get(
+        urlPathMatching("^/penalty/financial-data/ZECL/.*")
+      ),
+      aResponse()
+        .withStatus(CONFLICT)
+        .withBody(
+          "{\"failures\":[{\"code\":\"DUPLICATE_SUBMISSION\",\"reason\":\"The remote endpoint has indicated duplicate submission.\"}]}"
+        )
+    )
+
+  def stubGetFinancialDetails422(): StubMapping =
+    stub(
+      get(
+        urlPathMatching("^/penalty/financial-data/ZECL/.*")
+      ),
+      aResponse()
+        .withStatus(UNPROCESSABLE_ENTITY)
+        .withBody(
+          "{\"failures\":[{\"code\":\"INVALID_ID\",\"reason\":\"The remote endpoint has indicated that reference id is invalid.\"}]}"
+        )
     )
 
 }

--- a/test-common/uk/gov/hmrc/economiccrimelevyaccount/EclTestData.scala
+++ b/test-common/uk/gov/hmrc/economiccrimelevyaccount/EclTestData.scala
@@ -34,6 +34,8 @@ case class ValidFinancialDataResponse(financialDataResponse: FinancialData)
 
 trait EclTestData {
 
+  val uuidRegex: String = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+
   implicit val arbInstant: Arbitrary[Instant] = Arbitrary {
     Instant.now()
   }

--- a/test/uk/gov/hmrc/economiccrimelevyaccount/connectors/IntegrationFrameworkConnectorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyaccount/connectors/IntegrationFrameworkConnectorSpec.scala
@@ -19,19 +19,18 @@ package uk.gov.hmrc.economiccrimelevyaccount.connectors
 import org.mockito.ArgumentMatchers.any
 import play.api.libs.json.Json
 import uk.gov.hmrc.economiccrimelevyaccount.base.SpecBase
+import uk.gov.hmrc.economiccrimelevyaccount.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyaccount.models.EclReference
 import uk.gov.hmrc.economiccrimelevyaccount.models.integrationframework.FinancialData
-import uk.gov.hmrc.http.{HttpResponse, UpstreamErrorResponse}
-import uk.gov.hmrc.economiccrimelevyaccount.generators.CachedArbitraries._
+import uk.gov.hmrc.http.HttpResponse
 import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
 
 import scala.concurrent.Future
-import scala.util.{Failure, Try}
 
 class IntegrationFrameworkConnectorSpec extends SpecBase {
   val mockHttpClient: HttpClientV2       = mock[HttpClientV2]
   val mockRequestBuilder: RequestBuilder = mock[RequestBuilder]
-  val connector                          = new IntegrationFrameworkConnector(appConfig, mockHttpClient, config, actorSystem)
+  val connector                          = new IntegrationFrameworkConnector(appConfig, mockHttpClient)
 
   override def beforeEach(): Unit = {
     reset(mockRequestBuilder)
@@ -51,30 +50,6 @@ class IntegrationFrameworkConnectorSpec extends SpecBase {
           .thenReturn(Future.successful(HttpResponse.apply(OK, Json.stringify(Json.toJson(financialData)))))
 
         await(connector.getFinancialDetails(eclReference)).isInstanceOf[FinancialData] shouldBe true
-    }
-
-    "retries when a 500x error is returned from integration framework" in forAll {
-      (
-        eclReference: EclReference
-      ) =>
-        beforeEach()
-
-        val errorMessage = "internal server error"
-        when(mockHttpClient.get(any())(any())).thenReturn(mockRequestBuilder)
-        when(mockRequestBuilder.setHeader(any(), any(), any())).thenReturn(mockRequestBuilder)
-        when(mockRequestBuilder.withBody(any())(any(), any(), any())).thenReturn(mockRequestBuilder)
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(Future.successful(HttpResponse.apply(INTERNAL_SERVER_ERROR, errorMessage)))
-
-        Try(await(connector.getFinancialDetails(eclReference))) match {
-          case Failure(UpstreamErrorResponse(msg, _, _, _)) =>
-            msg shouldEqual errorMessage
-          case _                                            =>
-            fail("expected UpstreamErrorResponse when an error is received from IF")
-        }
-
-        verify(mockRequestBuilder, times(2))
-          .execute(any(), any())
     }
   }
 }

--- a/test/uk/gov/hmrc/economiccrimelevyaccount/utils/CorrelationIdHelperSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyaccount/utils/CorrelationIdHelperSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.economiccrimelevyaccount.utils
 
 import play.api.test.FakeRequest
 import uk.gov.hmrc.economiccrimelevyaccount.base.SpecBase
-import uk.gov.hmrc.economiccrimelevyaccount.utils.CorrelationIdHelper.HEADER_X_CORRELATION_ID
+import uk.gov.hmrc.economiccrimelevyaccount.models.CustomHeaderNames
 
 import java.util.UUID
 
@@ -36,12 +36,12 @@ class CorrelationIdHelperSpec extends SpecBase {
     }
 
     "not add the HEADER_X_CORRELATION_ID header to the HeaderCarrier extra headers if present" in {
-      val fakeRequest = FakeRequest.apply().withHeaders((HEADER_X_CORRELATION_ID, "existingHeader"))
+      val fakeRequest = FakeRequest.apply().withHeaders((CustomHeaderNames.xCorrelationId, "existingHeader"))
 
       val result = CorrelationIdHelper.headerCarrierWithCorrelationId(fakeRequest)
 
-      result.extraHeaders                                        shouldBe empty
-      result.headers(scala.Seq(HEADER_X_CORRELATION_ID)).head._2 shouldBe "existingHeader"
+      result.extraHeaders                                                 shouldBe empty
+      result.headers(scala.Seq(CustomHeaderNames.xCorrelationId)).head._2 shouldBe "existingHeader"
     }
   }
 }


### PR DESCRIPTION
- We had to remove the retries from the Get Financial Details API call, as the API will throw a **409** with the error message, "**Duplicate submission using the same correlation id.**" when a retry kicks in.