### PR TITLE
DDCYLS-5842 - amending the integration framework financials API date from date to 1st June 2023

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -74,7 +74,7 @@ microservice {
       host = localhost
       port = 14004
       bearerToken = test
-      dateFrom = "2023-03-01"
+      dateFrom = "2023-06-01"
       environment = test
     }
   }


### PR DESCRIPTION
amending the integration framework financials API date from date to 1st June 2023. This is a request from the DSM to give ETMP time to develop a strategic solution to an invalid date range error they are seeing when the dateFrom - DateTo date range is greater than 999 days.