### PR TITLE
DDCYLS-6175: amending get financials API date to date to be current date not plus 1 year

### DIFF
--- a/app/uk/gov/hmrc/economiccrimelevyaccount/connectors/IntegrationFrameworkConnector.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyaccount/connectors/IntegrationFrameworkConnector.scala
@@ -59,6 +59,7 @@ class IntegrationFrameworkConnector @Inject() (
       .setHeader((CustomHeaderNames.environment, appConfig.integrationFrameworkEnvironment))
       .setHeader((CustomHeaderNames.correlationId, correlationId))
       .executeAndDeserialise[FinancialData]
+
   }
 
   private def financialDetailsQueryParams: Seq[(String, String)] = Seq(
@@ -66,7 +67,7 @@ class IntegrationFrameworkConnector @Inject() (
       QueryParams.dateFrom,
       appConfig.integrationFrameworkDateFrom.format(DateTimeFormatter.ISO_LOCAL_DATE)
     ),
-    (QueryParams.dateTo, LocalDate.now().plusYears(1).format(DateTimeFormatter.ISO_LOCAL_DATE)),
+    (QueryParams.dateTo, LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE)),
     (QueryParams.accruingInterest, "true"),
     (QueryParams.clearedItems, "true"),
     (QueryParams.lockInformation, "true"),


### PR DESCRIPTION
amending the integration framework financials API 'date to' date to be the current date and not current date plus 1 year.